### PR TITLE
add mimir chart with chart dependency

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -2,3 +2,5 @@ replace-chart-version-with-git: true
 generate-metadata: true
 chart-dir: ./helm/mimir
 destination: ./build
+ct-config: ./.circleci/ct-config.yaml
+catalog-base-url: https://giantswarm.github.io/giantswarm-catalog/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,17 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.8.1
+  architect: giantswarm/architect@4.28.1
 
 workflows:
   package-and-push-chart-on-tag:
     jobs:
       - architect/push-to-app-catalog:
-          context: "architect"
-          # executor: "app-build-suite" # uncomment this if you want automatic metadata generation and helm chart linting
-          name: "package and push mimir chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
-          chart: "mimir"
+          context: architect
+          executor: app-build-suite
+          name: control-plane-catalog
+          app_catalog: control-plane-catalog
+          app_catalog_test: control-plane-test-catalog
+          chart: mimir
           # Trigger job on git tag.
           filters:
             tags:

--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,0 +1,3 @@
+---
+chart-repos:
+- mimir=https://github.com/grafana/mimir

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+helm/mimir/charts/*.tgz
+helm/mimir/Chart.lock

--- a/helm/mimir/Chart.yaml
+++ b/helm/mimir/Chart.yaml
@@ -1,22 +1,18 @@
 apiVersion: v2
-appVersion: 0.0.1
-
-# Please make sure your name DOES NOT end in "app" or "-app".
+appVersion: 2.7.1
 name: mimir
-
-# Please describe what the app provides in a sentence or two.
-description: Please add description
-
+description: A Helm chart for grafana's Mimir
+icon:  https://s.giantswarm.io/app-icons/grafana-mimir/1/light.svg
 home: https://github.com/giantswarm/mimir-app
-
-# If you have an icon/logo, you should add it to https://github.com/giantswarm/web-assets
-# and set the final URL as a value here and uncomment.
-#icon: https://s.giantswarm.io/app-icons/example/1/light.svg
-
+maintainers:
+  - name: giantswarm/team-atlas
+    email: team-atlas@giantswarm.io
 sources:
-- https://github.com/some-org/some-repo
-version: 0.0.0-dev # [[ .Version ]] if you're using architect instead of app-build-suite
+  - https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed
+dependencies:
+  - name: mimir-distributed
+    version: 4.3.0
+    repository: https://grafana.github.io/helm-charts
+version: 0.0.1
 annotations:
-  application.giantswarm.io/team: TEAM-NAME # used through .Chart.Annotations.team (not replaced automatically)
-  branch: my-branch # Used through .Chart.Annotations.branch (This is not replaced automatically)
-  commit: f00bar # Used through .Chart.Annotations.commit (This is not replaced automatically)
+  application.giantswarm.io/team: atlas

--- a/helm/mimir/templates/_helpers.tpl
+++ b/helm/mimir/templates/_helpers.tpl
@@ -2,37 +2,159 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
-{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- define "mimir.name" -}}
+{{- default ( include "mimir.infixName" . ) .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
-{{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- define "mimir.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default ( include "mimir.infixName" . ) .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Calculate the infix for naming
+*/}}
+{{- define "mimir.infixName" -}}
+{{- if and .Values.enterprise.enabled .Values.enterprise.legacyLabels -}}enterprise-metrics{{- else -}}mimir{{- end -}}
+{{- end -}}
+
+
+{{/*
+Resource labels
+Params:
+  ctx = . context
+  component = component name (optional)
+  rolloutZoneName = rollout zone name (optional)
+*/}}
+{{- define "mimir.labels" -}}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}
+{{- if .ctx.Values.enterprise.legacyLabels }}
+{{- if .component -}}
+app: {{ include "mimir.name" .ctx }}-{{ .component }}
+{{- else -}}
+app: {{ include "mimir.name" .ctx }}
+{{- end }}
+chart: {{ template "mimir.chart" .ctx }}
+heritage: {{ .ctx.Release.Service }}
+release: {{ .ctx.Release.Name }}
+
+{{- else -}}
+
+helm.sh/chart: {{ include "mimir.chart" .ctx }}
+app.kubernetes.io/name: {{ include "mimir.name" .ctx }}
+app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+{{- if .component }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- if .memberlist }}
+app.kubernetes.io/part-of: memberlist
+{{- end }}
+{{- if .ctx.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+{{- end }}
+{{- if .rolloutZoneName }}
+{{-   if not .component }}
+{{-     printf "Component name cannot be empty if rolloutZoneName (%s) is set" .rolloutZoneName | fail }}
+{{-   end }}
+name: "{{ .component }}-{{ .rolloutZoneName }}" {{- /* Currently required for rollout-operator. https://github.com/grafana/rollout-operator/issues/15 */}}
+rollout-group: {{ .component }}
+zone: {{ .rolloutZoneName }}
+{{- end }}
 {{- end -}}
 
 {{/*
-Selector labels
+POD labels
+Params:
+  ctx = . context
+  component = name of the component
+  memberlist = true if part of memberlist gossip ring
+  rolloutZoneName = rollout zone name (optional)
 */}}
-{{- define "labels.selector" -}}
-app.kubernetes.io/name: {{ include "name" . | quote }}
-app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- define "mimir.podLabels" -}}
+{{- if .ctx.Values.enterprise.legacyLabels }}
+{{- if .component -}}
+app: {{ include "mimir.name" .ctx }}-{{ .component }}
+{{- if not .rolloutZoneName }}
+name: {{ .component }}
+{{- end }}
+{{- end }}
+{{- if .memberlist }}
+gossip_ring_member: "true"
+{{- end -}}
+{{- if .component }}
+target: {{ .component }}
+release: {{ .ctx.Release.Name }}
+{{- end }}
+{{- else -}}
+helm.sh/chart: {{ include "mimir.chart" .ctx }}
+app.kubernetes.io/name: {{ include "mimir.name" .ctx }}
+app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+app.kubernetes.io/version: {{ .ctx.Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+{{- if .component }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- if .memberlist }}
+app.kubernetes.io/part-of: memberlist
+{{- end }}
+{{- end }}
+{{- $componentSection := include "mimir.componentSectionFromName" . | fromYaml }}
+{{- with ($componentSection).podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- if .rolloutZoneName }}
+{{-   if not .component }}
+{{-     printf "Component name cannot be empty if rolloutZoneName (%s) is set" .rolloutZoneName | fail }}
+{{-   end }}
+name: "{{ .component }}-{{ .rolloutZoneName }}" {{- /* Currently required for rollout-operator. https://github.com/grafana/rollout-operator/issues/15 */}}
+rollout-group: {{ .component }}
+zone: {{ .rolloutZoneName }}
+{{- end }}
 {{- end -}}
 
+
 {{/*
-Common labels
+Service selector labels
+Params:
+  ctx = . context
+  component = name of the component
+  rolloutZoneName = rollout zone name (optional)
 */}}
-{{- define "labels.common" -}}
-{{ include "labels.selector" . }}
-app.giantswarm.io/branch: {{ .Chart.Annotations.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
-application.giantswarm.io/commit: {{ .Chart.Annotations.commit | quote }}
-application.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-application.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
-giantswarm.io/managed-by: {{ .Release.Name | quote }}
-giantswarm.io/service-type: {{ .Values.serviceType }}
-helm.sh/chart: {{ include "chart" . | quote }}
+{{- define "mimir.selectorLabels" -}}
+{{- if .ctx.Values.enterprise.legacyLabels }}
+{{- if .component -}}
+app: {{ include "mimir.name" .ctx }}-{{ .component }}
+{{- end }}
+release: {{ .ctx.Release.Name }}
+{{- else -}}
+app.kubernetes.io/name: {{ include "mimir.name" .ctx }}
+app.kubernetes.io/instance: {{ .ctx.Release.Name }}
+{{- if .component }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- end -}}
+{{- if .rolloutZoneName }}
+{{-   if not .component }}
+{{-     printf "Component name cannot be empty if rolloutZoneName (%s) is set" .rolloutZoneName | fail }}
+{{-   end }}
+rollout-group: {{ .component }}
+zone: {{ .rolloutZoneName }}
+{{- end }}
 {{- end -}}
 

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -1,12 +1,2 @@
-name: mimir
-serviceType: managed
+mimir:
 
-project:
-  branch: "[[ .Branch ]]"
-  commit: "[[ .SHA ]]"
-
-image:
-  registry: quay.io
-  name: giantswarm/mimir
-  tag: v0.0.1
-  pullPolicy: IfNotPresent


### PR DESCRIPTION
This PR adds the Helm chart for Mimir based on the upstream repo : https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed
It's already using chart-dependency 
