### PR TITLE
improve gauss sample config for less dropped metrics

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -108,6 +108,8 @@ Default `ingester.max-global-series-per-user=150000` results in rate-limiting.
 We have to drasticaly increase it.
 
 Default `max-label-names-per-series=30` is a bit too short.
+- `distributor.ingestion-rate-limit` defaults to 10000 items/s
+- `distributor.ingestion-burst-size` defaults to 200000
 
 In `.mimir.ingester`:
 ```
@@ -115,8 +117,10 @@ extraArgs:
   ingester.max-global-series-per-user: 1500000
 ```
 
-For max-label-names-per-series, we still have to define which component should have this setting:
+In `.mimir.distributor`:
 ```
 extraArgs:
-  - validation.max-label-names-per-series=40
+  validation.max-label-names-per-series: 40
+  distributor.ingestion-rate-limit: 20000
+  distributor.ingestion-burst-size: 400000
 ```

--- a/sample_configs/mimir-user-values-gauss.yaml
+++ b/sample_configs/mimir-user-values-gauss.yaml
@@ -10,6 +10,9 @@ mimir:
         cpu: 100m
         memory: 512Mi
 
+    extraArgs:
+      validation.max-label-names-per-series: 40
+
   ingester:
     # -- Total number of replicas for the ingester across all availability zones
     # If ingester.zoneAwareReplication.enabled=false, this number is taken as is.
@@ -21,6 +24,8 @@ mimir:
 
     extraArgs:
       ingester.max-global-series-per-user: 1500000
+      distributor.ingestion-rate-limit: 20000
+      distributor.ingestion-burst-size: 400000
 
     statefulSet:
       enabled: true
@@ -295,7 +300,8 @@ mimir:
         username: Tenant1
         # -- The basic auth password for nginx
         password: 1tnaneT
-
+        
   metaMonitoring:
     serviceMonitor:
       enabled: true
+


### PR DESCRIPTION
This PR improves test config on gauss, so we have less dropped samples.
Towards https://github.com/giantswarm/roadmap/issues/2265

![image](https://user-images.githubusercontent.com/12008875/234922464-dc397684-c31a-4e16-aaf7-f45b0b84f0dd.png)