### PR TITLE
add condition for additional rbac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change registry from `docker.io` to `gsoci.azurecr.io`
+- Add condition for additional rbac.
 
 ## [0.4.0] - 2024-01-24
 

--- a/helm/mimir/templates/capi-additional-rbac.yaml
+++ b/helm/mimir/templates/capi-additional-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.psp.enabled }}
+{{- if and .Values.psp.enabled .Values.mimir.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
Without this condition, the app is trying to deploy only the additional rbac without pulling the upstream chart, leading to failing apps on several installations.
