### PR TITLE
add 30s scrape interval for service monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added a default scrape interval value of 30s for service monitors (if they're used).
+
 ## [0.4.2] - 2024-02-13
 
 ### Changed

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -28,6 +28,11 @@ mimir:
         - hostPath
         - projected
 
+  metaMonitoring:
+    serviceMonitor:
+      # We need to se this value to have the mixin rules work.
+      interval: 30s
+
   alertmanager:
     enabled: false
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3162

Queries used in the mimir mixin dashboards were not able to scrape anything due to the lack of default scrape interval and using rates over 1m time period. 
This PR adds a default 30s scrape interval for mimir's SM to solve this issue. 

:heavy_check_mark: This was tested on `golem` and working.
