### PR TITLE
set 'client_max_body_size' for the gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add ingress secret resource template for "ingress only" basic auth.
 
+### Changed
+
+- Specify `client_max_body_size` for the gateway config.
+
 ## [0.6.0] - 2024-05-13
 
 ### Changed

--- a/helm/mimir/values.schema.json
+++ b/helm/mimir/values.schema.json
@@ -295,6 +295,14 @@
                         "nginx": {
                             "type": "object",
                             "properties": {
+                                "config": {
+                                    "type": "object",
+                                    "properties": {
+                                        "serverSnippet": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
                                 "image": {
                                     "type": "object",
                                     "properties": {

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -293,3 +293,7 @@ mimir:
         registry: gsoci.azurecr.io
         repository: giantswarm/nginx-unprivileged
         tag: 1.26-alpine
+
+      config:
+        serverSnippet: |
+          client_max_body_size 50m;


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3217

This PR sets the `client_max_body_size` property for the gateway which is needed to avoid 413 "request body too large" errors when sending metrics from the prometheus-agents to mimir
