### PR TITLE
add annotation to the ingesters to exclude those from the kube-downsc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Push to `capz-app-collection`
+- Push to `capz-app-collection`.
+- Add annotation to the ingester to exclude it from the `kube-downscaler` scope.
 
 ## [0.6.1] - 2024-06-06
 

--- a/helm/mimir/values.schema.json
+++ b/helm/mimir/values.schema.json
@@ -348,6 +348,14 @@
                 "ingester": {
                     "type": "object",
                     "properties": {
+                        "podAnnotations": {
+                            "type": "object",
+                            "properties": {
+                                "downscaler/exclude": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
                         "podDisruptionBudget": {
                             "type": "object",
                             "properties": {

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -99,6 +99,9 @@ mimir:
         cpu: 1
         memory: 8Gi
 
+    podAnnotations:
+      downscaler/exclude: true
+
     # -- Pod Disruption Budget for ingester, this will be applied across availability zones to prevent losing redundancy
     podDisruptionBudget:
       maxUnavailable: 1


### PR DESCRIPTION
As I'm gonna deploy the `kube-downscaler` on `golem` and hopefully everywhere, I want to make sure that the ingesters are excluded from the downscaling process as they're not supposed to be below 3 replicas.
