### PR TITLE
add datasource configmap template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add datasource configmap template.
+
 ## [0.9.0] - 2024-07-16
 
 ### Changed

--- a/helm/mimir/templates/datasource.yaml
+++ b/helm/mimir/templates/datasource.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.mimir.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: mimir
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: mimir
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: mimir
+    application.giantswarm.io/team: atlas
+    app.giantswarm.io/kind: datasource
+  name: mimir-grafana-datasource
+  namespace: {{ .Release.Namespace }}
+data:
+  mimir-datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+    - name: Mimir
+        type: prometheus
+        uid: mimir
+        url: http://mimir-gateway.{{ .Release.Namespace }}.svc/prometheus
+        access: proxy
+        basicAuth: false
+        isDefault: {{ .Values.mimir.enabled }}
+        # The jsonData field isn't case-sensitive so even with a wrong one the datasource will work.
+        # However it might become handy in the future for potential specific needs.
+        jsonData:
+        httpMethod: "POST"
+        prometheusType: mimir
+        mimirVersion: 2.12.0
+        # Set the prometheus scrape interval of 60s to fix https://github.com/giantswarm/giantswarm/issues/29865
+        timeInterval: 60s
+        cacheLevel: none
+{{- end }}


### PR DESCRIPTION
This PR helps avoiding overriding of extrraObjects by config repos by directly deploying the datasource cm when mimir is enabled.
