### PR TITLE
fix grafana/mimir datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix grafana/mimir datasource
+
 ## [0.10.0] - 2024-07-18
 
 ### Added

--- a/helm/mimir/templates/datasource.yaml
+++ b/helm/mimir/templates/datasource.yaml
@@ -18,19 +18,19 @@ data:
     apiVersion: 1
     datasources:
     - name: Mimir
-        type: prometheus
-        uid: mimir
-        url: http://mimir-gateway.{{ .Release.Namespace }}.svc/prometheus
-        access: proxy
-        basicAuth: false
-        isDefault: {{ .Values.mimir.enabled }}
-        # The jsonData field isn't case-sensitive so even with a wrong one the datasource will work.
-        # However it might become handy in the future for potential specific needs.
-        jsonData:
-        httpMethod: "POST"
-        prometheusType: mimir
-        mimirVersion: 2.12.0
-        # Set the prometheus scrape interval of 60s to fix https://github.com/giantswarm/giantswarm/issues/29865
-        timeInterval: 60s
-        cacheLevel: none
+      type: prometheus
+      uid: mimir
+      url: http://mimir-gateway.{{ .Release.Namespace }}.svc/prometheus
+      access: proxy
+      basicAuth: false
+      isDefault: {{ .Values.mimir.enabled }}
+      # The jsonData field isn't case-sensitive so even with a wrong one the datasource will work.
+      # However it might become handy in the future for potential specific needs.
+      jsonData:
+      httpMethod: "POST"
+      prometheusType: mimir
+      mimirVersion: 2.12.0
+      # Set the prometheus scrape interval of 60s to fix https://github.com/giantswarm/giantswarm/issues/29865
+      timeInterval: 60s
+      cacheLevel: none
 {{- end }}


### PR DESCRIPTION
This PR fixes grafana/mimir datasource.

The datasource was introduced here: https://github.com/giantswarm/mimir-app/pull/114
and released with mimir-app 0.10.0

It was generating these errors at grafana startup, breaking grafana:
```
logger=provisioning t=2024-07-19T15:53:50.180629244Z level=error msg="Failed to provision data sources" error="Datasource provisioning error: yaml: line 4: mapping values are not allowed in this context"                                   
logger=context userId=1 orgId=1 uname=admin t=2024-07-19T15:53:50.180689998Z level=error msg= error="Datasource provisioning error: yaml: line 4: mapping values are not allowed in this context" remote_addr=[::1] traceID=                  
logger=context userId=1 orgId=1 uname=admin t=2024-07-19T15:53:50.180713518Z level=error msg="Request Completed" method=POST path=/api/admin/provisioning/datasources/reload status=500 remote_addr=[::1] time_ms=13 duration=13.956691ms size
=48 referer= handler=/api/admin/provisioning/datasources/reload status_source=server                                                                                                                                                          
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
