### PR TITLE
add ScaledObjects resources templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ScaledObjects` resources templates for the `querier`, the `distributor` and the `gateway`.
+
 ## [0.17.0] - 2025-04-14
 
 ### Changed

--- a/helm/mimir/templates/distributor/scaled-object.yaml
+++ b/helm/mimir/templates/distributor/scaled-object.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.kedaAutoscaling.distributor.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "mimir.readFullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    name: {{ include "mimir.readFullname" . }}
+  {{- if .Values.kedaAutoscaling.distributor.horizontalPodAutoscalerConfig }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      {{- toYaml .Values.kedaAutoscaling.distributor.horizontalPodAutoscalerConfig | nindent 6 }}
+  {{- end }}
+  pollingInterval: {{ .Values.kedaAutoscaling.distributor.pollingInterval }}
+  cooldownPeriod: {{ .Values.kedaAutoscaling.distributor.cooldownPeriod }}
+  minReplicaCount: {{ .Values.kedaAutoscaling.distributor.minReplicas }}
+  maxReplicaCount: {{ .Values.kedaAutoscaling.distributor.maxReplicas }}
+  triggers:
+  - type: memory
+    metricType: Utilization
+    metadata:
+      value: {{ .Values.kedaAutoscaling.distributor.targetMemoryUtilizationPercentage | quote }}
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: {{ .Values.kedaAutoscaling.distributor.targetCPUUtilizationPercentage | quote }}
+{{- end }}

--- a/helm/mimir/templates/distributor/scaled-object.yaml
+++ b/helm/mimir/templates/distributor/scaled-object.yaml
@@ -2,11 +2,11 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "mimir.readFullname" . }}
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
-    name: {{ include "mimir.readFullname" . }}
+    name: {{ include "mimir.resourceName" (dict "ctx" . "component" "distributor") }}
   {{- if .Values.kedaAutoscaling.distributor.horizontalPodAutoscalerConfig }}
   advanced:
     horizontalPodAutoscalerConfig:

--- a/helm/mimir/templates/distributor/scaled-object.yaml
+++ b/helm/mimir/templates/distributor/scaled-object.yaml
@@ -17,12 +17,5 @@ spec:
   minReplicaCount: {{ .Values.kedaAutoscaling.distributor.minReplicas }}
   maxReplicaCount: {{ .Values.kedaAutoscaling.distributor.maxReplicas }}
   triggers:
-  - type: memory
-    metricType: Utilization
-    metadata:
-      value: {{ .Values.kedaAutoscaling.distributor.targetMemoryUtilizationPercentage | quote }}
-  - type: cpu
-    metricType: Utilization
-    metadata:
-      value: {{ .Values.kedaAutoscaling.distributor.targetCPUUtilizationPercentage | quote }}
+  {{- toYaml .Values.kedaAutoscaling.querier.triggers | nindent 2 }}
 {{- end }}

--- a/helm/mimir/templates/gateway/scaled-object.yaml
+++ b/helm/mimir/templates/gateway/scaled-object.yaml
@@ -17,12 +17,5 @@ spec:
   minReplicaCount: {{ .Values.kedaAutoscaling.gateway.minReplicas }}
   maxReplicaCount: {{ .Values.kedaAutoscaling.gateway.maxReplicas }}
   triggers:
-  - type: memory
-    metricType: Utilization
-    metadata:
-      value: {{ .Values.kedaAutoscaling.gateway.targetMemoryUtilizationPercentage | quote }}
-  - type: cpu
-    metricType: Utilization
-    metadata:
-      value: {{ .Values.kedaAutoscaling.gateway.targetCPUUtilizationPercentage | quote }}
+  {{- toYaml .Values.kedaAutoscaling.querier.triggers | nindent 2 }}
 {{- end }}

--- a/helm/mimir/templates/gateway/scaled-object.yaml
+++ b/helm/mimir/templates/gateway/scaled-object.yaml
@@ -2,11 +2,11 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "mimir.readFullname" . }}
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
-    name: {{ include "mimir.readFullname" . }}
+    name: {{ include "mimir.resourceName" (dict "ctx" . "component" "gateway") }}
   {{- if .Values.kedaAutoscaling.gateway.horizontalPodAutoscalerConfig }}
   advanced:
     horizontalPodAutoscalerConfig:

--- a/helm/mimir/templates/gateway/scaled-object.yaml
+++ b/helm/mimir/templates/gateway/scaled-object.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.kedaAutoscaling.gateway.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "mimir.readFullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    name: {{ include "mimir.readFullname" . }}
+  {{- if .Values.kedaAutoscaling.gateway.horizontalPodAutoscalerConfig }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      {{- toYaml .Values.kedaAutoscaling.gateway.horizontalPodAutoscalerConfig | nindent 6 }}
+  {{- end }}
+  pollingInterval: {{ .Values.kedaAutoscaling.gateway.pollingInterval }}
+  cooldownPeriod: {{ .Values.kedaAutoscaling.gateway.cooldownPeriod }}
+  minReplicaCount: {{ .Values.kedaAutoscaling.gateway.minReplicas }}
+  maxReplicaCount: {{ .Values.kedaAutoscaling.gateway.maxReplicas }}
+  triggers:
+  - type: memory
+    metricType: Utilization
+    metadata:
+      value: {{ .Values.kedaAutoscaling.gateway.targetMemoryUtilizationPercentage | quote }}
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: {{ .Values.kedaAutoscaling.gateway.targetCPUUtilizationPercentage | quote }}
+{{- end }}

--- a/helm/mimir/templates/querier/scaled-object.yaml
+++ b/helm/mimir/templates/querier/scaled-object.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.kedaAutoscaling.querier.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "mimir.readFullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    name: {{ include "mimir.readFullname" . }}
+  {{- if .Values.kedaAutoscaling.querier.horizontalPodAutoscalerConfig }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      {{- toYaml .Values.kedaAutoscaling.querier.horizontalPodAutoscalerConfig | nindent 6 }}
+  {{- end }}
+  pollingInterval: {{ .Values.kedaAutoscaling.querier.pollingInterval }}
+  cooldownPeriod: {{ .Values.kedaAutoscaling.querier.cooldownPeriod }}
+  minReplicaCount: {{ .Values.kedaAutoscaling.querier.minReplicas }}
+  maxReplicaCount: {{ .Values.kedaAutoscaling.querier.maxReplicas }}
+  triggers:
+  - type: memory
+    metricType: Utilization
+    metadata:
+      value: {{ .Values.kedaAutoscaling.querier.targetMemoryUtilizationPercentage | quote }}
+  - type: cpu
+    metricType: Utilization
+    metadata:
+      value: {{ .Values.kedaAutoscaling.querier.targetCPUUtilizationPercentage | quote }}
+{{- end }}

--- a/helm/mimir/templates/querier/scaled-object.yaml
+++ b/helm/mimir/templates/querier/scaled-object.yaml
@@ -2,11 +2,11 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "mimir.readFullname" . }}
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
-    name: {{ include "mimir.readFullname" . }}
+    name: {{ include "mimir.resourceName" (dict "ctx" . "component" "querier") }}
   {{- if .Values.kedaAutoscaling.querier.horizontalPodAutoscalerConfig }}
   advanced:
     horizontalPodAutoscalerConfig:

--- a/helm/mimir/templates/querier/scaled-object.yaml
+++ b/helm/mimir/templates/querier/scaled-object.yaml
@@ -17,12 +17,5 @@ spec:
   minReplicaCount: {{ .Values.kedaAutoscaling.querier.minReplicas }}
   maxReplicaCount: {{ .Values.kedaAutoscaling.querier.maxReplicas }}
   triggers:
-  - type: memory
-    metricType: Utilization
-    metadata:
-      value: {{ .Values.kedaAutoscaling.querier.targetMemoryUtilizationPercentage | quote }}
-  - type: cpu
-    metricType: Utilization
-    metadata:
-      value: {{ .Values.kedaAutoscaling.querier.targetCPUUtilizationPercentage | quote }}
+  {{- toYaml .Values.kedaAutoscaling.querier.triggers | nindent 2 }}
 {{- end }}

--- a/helm/mimir/values.schema.json
+++ b/helm/mimir/values.schema.json
@@ -2,6 +2,68 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "alertmanager": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object",
+                    "properties": {
+                        "podAntiAffinity": {
+                            "type": "object",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "type": "array",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "topologyKey": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "weight": {
+                                                "type": "integer"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "replicas": {
+                    "type": "integer"
+                }
+            }
+        },
         "enterprise": {
             "type": "object",
             "properties": {
@@ -145,6 +207,184 @@
                 }
             }
         },
+        "kedaAutoscaling": {
+            "type": "object",
+            "properties": {
+                "distributor": {
+                    "type": "object",
+                    "properties": {
+                        "cooldownPeriod": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "horizontalPodAutoscalerConfig": {
+                            "type": "object",
+                            "properties": {
+                                "behavior": {
+                                    "type": "object",
+                                    "properties": {
+                                        "scaleDown": {
+                                            "type": "object",
+                                            "properties": {
+                                                "policies": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "periodSeconds": {
+                                                                "type": "integer"
+                                                            },
+                                                            "type": {
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "integer"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "maxReplicas": {
+                            "type": "integer"
+                        },
+                        "minReplicas": {
+                            "type": "integer"
+                        },
+                        "pollingInterval": {
+                            "type": "integer"
+                        },
+                        "targetCPUUtilizationPercentage": {
+                            "type": "string"
+                        },
+                        "targetMemoryUtilizationPercentage": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "gateway": {
+                    "type": "object",
+                    "properties": {
+                        "cooldownPeriod": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "horizontalPodAutoscalerConfig": {
+                            "type": "object"
+                        },
+                        "maxReplicas": {
+                            "type": "integer"
+                        },
+                        "minReplicas": {
+                            "type": "integer"
+                        },
+                        "pollingInterval": {
+                            "type": "integer"
+                        },
+                        "targetCPUUtilizationPercentage": {
+                            "type": "string"
+                        },
+                        "targetMemoryUtilizationPercentage": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "querier": {
+                    "type": "object",
+                    "properties": {
+                        "cooldownPeriod": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "horizontalPodAutoscalerConfig": {
+                            "type": "object",
+                            "properties": {
+                                "behavior": {
+                                    "type": "object",
+                                    "properties": {
+                                        "scaleDown": {
+                                            "type": "object",
+                                            "properties": {
+                                                "policies": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "periodSeconds": {
+                                                                "type": "integer"
+                                                            },
+                                                            "type": {
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "integer"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "stabilizationWindowSeconds": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        },
+                                        "scaleUp": {
+                                            "type": "object",
+                                            "properties": {
+                                                "policies": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "periodSeconds": {
+                                                                "type": "integer"
+                                                            },
+                                                            "type": {
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "type": "integer"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "stabilizationWindowSeconds": {
+                                                    "type": "integer"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "maxReplicas": {
+                            "type": "integer"
+                        },
+                        "minReplicas": {
+                            "type": "integer"
+                        },
+                        "pollingInterval": {
+                            "type": "integer"
+                        },
+                        "targetCPUUtilizationPercentage": {
+                            "type": "string"
+                        },
+                        "targetMemoryUtilizationPercentage": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "mimir": {
             "type": "object",
             "properties": {
@@ -161,6 +401,36 @@
                     "properties": {
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "verticalAutoscaling": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "maxAllowed": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "integer"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "minAllowed": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -295,9 +565,6 @@
                                         },
                                         "repository": {
                                             "type": "string"
-                                        },
-                                        "tag": {
-                                            "type": "string"
                                         }
                                     }
                                 }
@@ -340,13 +607,7 @@
                 "image": {
                     "type": "object",
                     "properties": {
-                        "pullPolicy": {
-                            "type": "string"
-                        },
                         "repository": {
-                            "type": "string"
-                        },
-                        "tag": {
                             "type": "string"
                         }
                     }
@@ -451,13 +712,7 @@
                         "image": {
                             "type": "object",
                             "properties": {
-                                "pullPolicy": {
-                                    "type": "string"
-                                },
                                 "repository": {
-                                    "type": "string"
-                                },
-                                "tag": {
                                     "type": "string"
                                 }
                             }
@@ -492,13 +747,7 @@
                         "image": {
                             "type": "object",
                             "properties": {
-                                "pullPolicy": {
-                                    "type": "string"
-                                },
                                 "repository": {
-                                    "type": "string"
-                                },
-                                "tag": {
                                     "type": "string"
                                 }
                             }
@@ -719,9 +968,6 @@
                 "rbac": {
                     "type": "object",
                     "properties": {
-                        "forcePSPOnKubernetes124": {
-                            "type": "boolean"
-                        },
                         "podSecurityPolicy": {
                             "type": "object",
                             "properties": {

--- a/helm/mimir/values.schema.json
+++ b/helm/mimir/values.schema.json
@@ -260,11 +260,27 @@
                         "pollingInterval": {
                             "type": "integer"
                         },
-                        "targetCPUUtilizationPercentage": {
-                            "type": "string"
-                        },
-                        "targetMemoryUtilizationPercentage": {
-                            "type": "string"
+                        "triggers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "metadata": {
+                                        "type": "object",
+                                        "properties": {
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "metricType": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -289,11 +305,27 @@
                         "pollingInterval": {
                             "type": "integer"
                         },
-                        "targetCPUUtilizationPercentage": {
-                            "type": "string"
-                        },
-                        "targetMemoryUtilizationPercentage": {
-                            "type": "string"
+                        "triggers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "metadata": {
+                                        "type": "object",
+                                        "properties": {
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "metricType": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -375,11 +407,27 @@
                         "pollingInterval": {
                             "type": "integer"
                         },
-                        "targetCPUUtilizationPercentage": {
-                            "type": "string"
-                        },
-                        "targetMemoryUtilizationPercentage": {
-                            "type": "string"
+                        "triggers": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "metadata": {
+                                        "type": "object",
+                                        "properties": {
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "metricType": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -74,8 +74,8 @@ kedaAutoscaling:
     enabled: false
     horizontalPodAutoscalerConfig:
       behavior:
-       scaleDown:
-        policies:
+        scaleDown:
+          policies:
           - periodSeconds: 600
             type: Percent
             value: 10

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -46,7 +46,7 @@ hpa:
 
 kedaAutoscaling:
   querier:
-    enabled: false
+    enabled: true
     horizontalPodAutoscalerConfig:
       behavior:
         scaleDown:
@@ -64,12 +64,19 @@ kedaAutoscaling:
               type: Pods
               value: 15
           stabilizationWindowSeconds: 60
+    triggers:
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: "90" # equivalent of targetMemoryUtilizationPercentage in HPA
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "90" # equivalent of targetCPUUtilizationPercentage in HPA
     pollingInterval: 30
     cooldownPeriod: 300
     minReplicas: 1
     maxReplicas: 3
-    targetCPUUtilizationPercentage: "90"
-    targetMemoryUtilizationPercentage: "90"
   distributor:
     enabled: false
     horizontalPodAutoscalerConfig:
@@ -79,21 +86,35 @@ kedaAutoscaling:
           - periodSeconds: 600
             type: Percent
             value: 10
+    triggers:
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: "90"
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "90"
     pollingInterval: 30
     cooldownPeriod: 300
     minReplicas: 1
     maxReplicas: 3
-    targetCPUUtilizationPercentage: "90"
-    targetMemoryUtilizationPercentage: "90"
   gateway:
     enabled: false
     horizontalPodAutoscalerConfig: {}
+    triggers:
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: "90"
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "90"
     pollingInterval: 30
     cooldownPeriod: 300
     minReplicas: 1
     maxReplicas: 3
-    targetCPUUtilizationPercentage: "90"
-    targetMemoryUtilizationPercentage: "90"
 
 # Default configuration for HA alertmanager
 alertmanager:

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -44,6 +44,57 @@ hpa:
             type: Percent
             value: 10
 
+kedaAutoscaling:
+  querier:
+    enabled: false
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          policies:
+            - periodSeconds: 120
+              type: Percent
+              value: 10
+          stabilizationWindowSeconds: 600
+        scaleUp:
+          policies:
+            - periodSeconds: 120
+              type: Percent
+              value: 50
+            - periodSeconds: 120
+              type: Pods
+              value: 15
+          stabilizationWindowSeconds: 60
+    pollingInterval: 30
+    cooldownPeriod: 300
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: "90"
+    targetMemoryUtilizationPercentage: "90"
+  distributor:
+    enabled: false
+    horizontalPodAutoscalerConfig:
+      behavior:
+       scaleDown:
+        policies:
+          - periodSeconds: 600
+            type: Percent
+            value: 10
+    pollingInterval: 30
+    cooldownPeriod: 300
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: "90"
+    targetMemoryUtilizationPercentage: "90"
+  gateway:
+    enabled: false
+    horizontalPodAutoscalerConfig: {}
+    pollingInterval: 30
+    cooldownPeriod: 300
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: "90"
+    targetMemoryUtilizationPercentage: "90"
+
 # Default configuration for HA alertmanager
 alertmanager:
   replicas: 3

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -68,11 +68,13 @@ kedaAutoscaling:
     - type: memory
       metricType: Utilization
       metadata:
-        value: "90" # equivalent of targetMemoryUtilizationPercentage in HPA
+        # equivalent of targetMemoryUtilizationPercentage in HPA
+        value: "90"
     - type: cpu
       metricType: Utilization
       metadata:
-        value: "90" # equivalent of targetCPUUtilizationPercentage in HPA
+        # equivalent of targetCPUUtilizationPercentage in HPA
+        value: "90"
     pollingInterval: 30
     cooldownPeriod: 300
     minReplicas: 1

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -46,7 +46,7 @@ hpa:
 
 kedaAutoscaling:
   querier:
-    enabled: true
+    enabled: false
     horizontalPodAutoscalerConfig:
       behavior:
         scaleDown:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33773

As described in the issue, I'll be pushing some changes upstream to allow anyone to define their own triggers for each ScaledObject resource. In the meantime, this PR allows us to migrate to Keda for autoscaling while not having to wait for upstream to accept the changes. 

We are doing this to be able to do a smooth migration to Keda without having to directly use the metrics triggers.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
