### PR TITLE
Add vertical pod autoscaling support for ruler and store_gateway components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added verticalAutoscaling configuration for ruler and store_gateway components to enable automatic resource scaling based on actual usage.
+
 ## [0.19.0] - 2025-08-25
 
 ### Changed

--- a/helm/mimir/templates/ruler/vertical-pod-autoscaler.yaml
+++ b/helm/mimir/templates/ruler/vertical-pod-autoscaler.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.mimir.enabled .Values.mimir.ruler.verticalAutoscaling.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler" "memberlist" true) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "ruler") | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: ruler
+      controlledValues: RequestsAndLimits
+      minAllowed:
+        cpu: {{ .Values.mimir.ruler.verticalAutoscaling.minAllowed.cpu }}
+        memory: {{ .Values.mimir.ruler.verticalAutoscaling.minAllowed.memory }}
+      maxAllowed:
+        cpu: {{ .Values.mimir.ruler.verticalAutoscaling.maxAllowed.cpu }}
+        memory: {{ .Values.mimir.ruler.verticalAutoscaling.maxAllowed.memory }}
+      mode: Auto
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mimir.resourceName" (dict "ctx" . "component" "ruler" "memberlist" true) }}
+  updatePolicy:
+    updateMode: Auto
+{{- end }}

--- a/helm/mimir/templates/store_gateway/vertical-pod-autoscaler.yaml
+++ b/helm/mimir/templates/store_gateway/vertical-pod-autoscaler.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.mimir.enabled .Values.mimir.store_gateway.verticalAutoscaling.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "mimir.resourceName" (dict "ctx" . "component" "store-gateway" "memberlist" true) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "mimir.labels" (dict "ctx" . "component" "store-gateway") | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: store-gateway
+      controlledValues: RequestsAndLimits
+      minAllowed:
+        cpu: {{ .Values.mimir.store_gateway.verticalAutoscaling.minAllowed.cpu }}
+        memory: {{ .Values.mimir.store_gateway.verticalAutoscaling.minAllowed.memory }}
+      maxAllowed:
+        cpu: {{ .Values.mimir.store_gateway.verticalAutoscaling.maxAllowed.cpu }}
+        memory: {{ .Values.mimir.store_gateway.verticalAutoscaling.maxAllowed.memory }}
+      mode: Auto
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "mimir.resourceName" (dict "ctx" . "component" "store-gateway" "memberlist" true) }}
+  updatePolicy:
+    updateMode: Auto
+{{- end }}

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -242,6 +242,15 @@ mimir:
         cpu: 100m
         memory: 128Mi
 
+    verticalAutoscaling:
+      enabled: true
+      minAllowed:
+        cpu: 100m
+        memory: 128Mi
+      maxAllowed:
+        cpu: 2
+        memory: 2Gi
+
     securityContext:
       seccompProfile:
         type: RuntimeDefault
@@ -294,6 +303,15 @@ mimir:
       requests:
         cpu: 100m
         memory: 512Mi
+
+    verticalAutoscaling:
+      enabled: true
+      minAllowed:
+        cpu: 100m
+        memory: 512Mi
+      maxAllowed:
+        cpu: 1
+        memory: 2Gi
 
     # -- Pod Disruption Budget for store-gateway, this will be applied across availability zones to prevent losing redundancy
     podDisruptionBudget:


### PR DESCRIPTION
- Added verticalAutoscaling configuration to ruler and store_gateway in values.yaml
- Created VPA Helm templates for both components
- Configured appropriate resource limits based on component usage patterns

This was done because the current memory efficiency of those 2 components is really bad (low request vs actually high usage). This should reduce the risk of killing nodes
