### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,12 @@ workflows:
           chart: mimir
           ct_config: ".circleci/ct-config.yml"
           persist_chart_archive: true
+          override_app_version: false
           # Trigger job on git tag.
           filters:
             tags:
               only: /^v.*/
-      
+
       - architect/run-tests-with-ats:
           name: run-chart-tests-with-ats
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [0.28.0] - 2026-04-22
 
 ### Fixed


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
