### PR TITLE
fix: disable servicemonitor for gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- disabled gateway metrics servicemonitor. Had been added in `0.29.0` but not working.
+
 ## [0.29.0] - 2026-07-23
 
 ### Changed

--- a/helm/mimir/values.yaml
+++ b/helm/mimir/values.yaml
@@ -533,6 +533,8 @@ mimir:
     replicas: 1
 
     service:
+      labels:
+        prometheus.io/service-monitor: "false"
       nameOverride: ""
 
     securityContext:


### PR DESCRIPTION
Latest upstream helm chart was adding a servicemonitor for the mimir-gateway, but it does not expose metrics, so we got alerts.
This PR disables scraping the mimir-gateway, and will clean the current alerts.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
